### PR TITLE
allow correct IP to be logged while behind a proxy server

### DIFF
--- a/fail2ban.php
+++ b/fail2ban.php
@@ -16,7 +16,9 @@ class fail2ban extends rcube_plugin
 
   function log($args)
   {
-    $log_entry = '[roundcube] FAILED login for ' .$args['user']. ' from ' .getenv('REMOTE_ADDR');
+    $remote_addr = !empty($_SERVER['HTTP_X_FORWARDED_FOR']) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
+    #$log_entry = '[roundcube] FAILED login for ' .$args['user']. ' from ' .getenv('REMOTE_ADDR');
+    $log_entry = '[roundcube] FAILED login for ' .$args['user']. ' from ' .$remote_addr;
     $log_config = rcmail::get_instance()->config->get('log_driver');
     $log_dir = rcmail::get_instance()->config->get('log_dir');
 


### PR DESCRIPTION
In response to #6 , this change should allow correct logging while behind a proxy server, testing will need to be done to verify this.

Props go out to @remoteclient for the code work.
